### PR TITLE
Added an “Agent Feedback” option to the Reason for Contact dropdown i...

### DIFF
--- a/plugins/swr-contact-form-ajax/swr-contact-form.php
+++ b/plugins/swr-contact-form-ajax/swr-contact-form.php
@@ -49,6 +49,7 @@ add_shortcode('swr_contact_form', function () {
                     <option value="General Inquiry">General Inquiry</option>
                     <option value="Support">Support</option>
                     <option value="Feedback">Feedback</option>
+                    <option value="Agent Feedback">Agent Feedback</option>
                     <option value="Partnership">Partnership</option>
                     <option value="Other">Other</option>
                 </select>


### PR DESCRIPTION
<!-- swrice-agent-generated -->
## Summary
Added an “Agent Feedback” option to the Reason for Contact dropdown in the Swrice Contact Form shortcode. Verified the updated PHP file passes syntax validation.

## Changes Made
- plugins/swr-contact-form-ajax/swr-contact-form.php

## Validation
php -l results:
- plugins/swr-contact-form-ajax/swr-contact-form.php: OK

## Limitations
This pull request was generated automatically by [Swrice Agent](https://agent.swrice.com) from the task description below. Please review the diff carefully before merging — automated changes may miss project-specific context that a human reviewer would catch.

## Original Task
> Please add a new option in the "Reason for Contact" dropdown, The new option name would be "Agent Feedback"